### PR TITLE
Update __init__.py

### DIFF
--- a/cisconverter/__init__.py
+++ b/cisconverter/__init__.py
@@ -65,7 +65,7 @@ class CISConverter:
         logging.debug(row)
 
     def parse_text(self):
-        with open(self.args.inputFilePath, 'rt') as inFile:
+        with open(self.args.inputFilePath, mode='rt', encoding='utf8') as inFile:
             logging.info(f'Parsing {self.args.inputFilePath}')
 
             row = None


### PR DESCRIPTION
Instructions for PDF dump explicitly state to use UTF-8. Adding line to parse_text to avoid "UnicodeDecodeError: 'charmap' codec can't decode byte" errors